### PR TITLE
Fix slider box sizing

### DIFF
--- a/scss/_InputRangeSlider.scss
+++ b/scss/_InputRangeSlider.scss
@@ -3,6 +3,7 @@
   background: $InputRange-slider-background;
   border: $InputRange-slider-border;
   border-radius: 100%;
+  box-sizing: content-box;
   cursor: pointer;
   display: block;
   height: $InputRange-slider-height;


### PR DESCRIPTION
Was `border-box`, now `content-box`
